### PR TITLE
Re-establish original behaviour of Read() method

### DIFF
--- a/hid_disabled.go
+++ b/hid_disabled.go
@@ -65,6 +65,12 @@ func (dev *Device) Read(b []byte) (int, error) {
 	return 0, ErrUnsupportedPlatform
 }
 
+// ReadTimeout retrieves an input report from a HID device. On platforms that build with
+// this file the implemented method just returns an error.
+func (dev *Device) ReadTimeout(b []byte, t int) (int, error) {
+	return 0, ErrUnsupportedPlatform
+}
+
 // GetFeatureReport retrieves a feature report from a HID device
 //
 // Set the first byte of []b to the Report ID of the report to be read. Make

--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -253,8 +253,7 @@ func (dev *Device) SendFeatureReport(b []byte) (int, error) {
 // return hid_read_timeout(dev, data, length, (dev->blocking)? -1: 0);
 func (dev *Device) Read(b []byte) (int, error) {
 	var timeout int
-	blocking := int(dev.device.blocking) == 1
-	if blocking {
+	if int(dev.device.blocking) == 1 {
 		timeout = -1
 	}
 	return dev.ReadTimeout(b, timeout)


### PR DESCRIPTION
The original Read() method was a wrapper to C.hid_read.
C.hid_read checks for the device blocking field
to pass a timeout value to C.hid_read_timeout accordingly:
if blocking is enabled, -1, else 0.

The changed introduced in https://github.com/karalabe/hid/pull/22
and merged in this fork breaks that and incorrectly assumes that
a 0 timeout means a blocking read. This commit allows to maintain
the original use of Read() while also allowing a package user to
make use of ReadTimeout(b, t)
ReadTimeout() was previously missing from hid_disable.go