### PR TITLE
Fixes for Windows

### DIFF
--- a/hid_enabled.go
+++ b/hid_enabled.go
@@ -52,7 +52,6 @@ import "C"
 
 import (
 	"errors"
-	"runtime"
 	"sync"
 	"unsafe"
 )
@@ -170,15 +169,9 @@ func (dev *Device) Write(b []byte) (int, error) {
 	if device == nil {
 		return 0, ErrDeviceClosed
 	}
-	// Prepend a HID report ID on Windows, other OSes don't need it
-	var report []byte
-	if runtime.GOOS == "windows" {
-		report = append([]byte{0x00}, b...)
-	} else {
-		report = b
-	}
+
 	// Execute the write operation
-	written := int(C.hid_write(device, (*C.uchar)(&report[0]), C.size_t(len(report))))
+	written := int(C.hid_write(device, (*C.uchar)(&b[0]), C.size_t(len(b))))
 	if written == -1 {
 		// If the write failed, verify if closed or other error
 		dev.lock.Lock()


### PR DESCRIPTION
My Ubikey did not work on Windows with 0x00 prepended to the message bytes